### PR TITLE
fixing spec - was failing

### DIFF
--- a/spec/bundler_ext/bundler_ext_spec.rb
+++ b/spec/bundler_ext/bundler_ext_spec.rb
@@ -72,6 +72,7 @@ require 'spec_helper'
       it "non-strict mode should load the libraries using env var list" do
         ENV['BUNDLER_EXT_GROUPS'] = 'test development blah'
         ENV['BUNDLER_EXT_NOSTRICT'] = 'true'
+        BundlerExt.system_require(@gemfile)
         defined?(Gem::Command).should be_true
       end
     end


### PR DESCRIPTION
SSIA

```
[09:13] <vondruch> Failures:
[09:13] <vondruch>   1) BundlerExt#system_require non-strict mode should load the libraries using env var list
[09:13] <vondruch>      Failure/Error: defined?(Gem::Command).should be_true
[09:13] <vondruch>        expected: true value
[09:13] <vondruch>             got: nil
```
