### PR TITLE
Lookup and activate versions of system installed gems

### DIFF
--- a/bundler_ext.gemspec
+++ b/bundler_ext.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency "bundler"
+  s.requirements = ['Install the linux_admin gem and set BEXT_ACTIVATE_VERSIONS to true to activate rpm/deb installed gems']
 
   s.add_development_dependency('rspec', '>=1.3.0')
 end

--- a/spec/bundler_ext/bundler_ext_spec.rb
+++ b/spec/bundler_ext/bundler_ext_spec.rb
@@ -1,5 +1,13 @@
 require 'spec_helper'
 
+# skip system specs unless we can load linux_admin
+skip_system = false
+begin
+  require 'linux_admin'
+rescue LoadError
+  skip_system = true
+end
+
   describe BundlerExt do
     before(:each) do
       @gemfile = 'spec/fixtures/Gemfile.in'
@@ -7,51 +15,55 @@ require 'spec_helper'
     after(:each) do
       ENV['BUNDLER_EXT_NOSTRICT'] = nil
       ENV['BUNDLER_EXT_GROUPS'] = nil
+      ENV['BUNDLER_PKG_PREFIX'] = nil
+      ENV['BEXT_ACTIVATE_VERSIONS'] = nil
+      ENV['BEXT_PKG_PREFIX'] = nil
     end
 
     describe "#parse_from_gemfile" do
       describe "with no group passed in" do
         it "should return nothing to require" do
           libs = BundlerExt.parse_from_gemfile(@gemfile)
-          libs.should be_an(Array)
-          libs.should_not include('deltacloud')
-          libs.should_not include('vcr')
+          libs.should be_an(Hash)
+          libs.keys.should_not include('deltacloud-client')
+          libs.keys.should_not include('vcr')
         end
       end
       describe "with :all passed in" do
         it "should return the list of system libraries in all groups to require" do
           libs = BundlerExt.parse_from_gemfile(@gemfile, :all)
-          libs.should be_an(Array)
-          libs.should include('deltacloud')
-          libs.should include('vcr')
+          libs.should be_an(Hash)
+          libs.keys.should include('deltacloud-client')
+          libs['deltacloud-client'][:files].should == ['deltacloud']
+          libs.keys.should include('vcr')
         end
       end
       describe "with group passed in" do
         it "should not return any deps that are not in the 'development' group" do
           libs = BundlerExt.parse_from_gemfile(@gemfile,'development')
-          libs.should be_an(Array)
-          libs.should_not include('deltacloud')
+          libs.should be_an(Hash)
+          libs.keys.should_not include('deltacloud-client')
         end
         it "should return only deps that are in the :test group" do
           libs = BundlerExt.parse_from_gemfile(@gemfile, :test)
-          libs.should be_an(Array)
-          libs.should_not include('deltacloud')
-          libs.should include('vcr')
+          libs.should be_an(Hash)
+          libs.keys.should_not include('deltacloud-client')
+          libs.keys.should include('vcr')
         end
         it "should return deps from both the :default and :test groups" do
           libs = BundlerExt.parse_from_gemfile(@gemfile, :default, :test)
-          libs.should be_an(Array)
-          libs.should include('deltacloud')
-          libs.should include('vcr')
+          libs.should be_an(Hash)
+          libs.keys.should include('deltacloud-client')
+          libs.keys.should include('vcr')
         end
       end
       it "should only return deps for the current platform" do
         libs = BundlerExt.parse_from_gemfile(@gemfile)
-        libs.should be_an(Array)
+        libs.should be_an(Hash)
         if RUBY_VERSION < "1.9"
-          libs.should_not include('cinch')
+          libs.keys.should_not include('cinch')
         else
-          libs.should_not include('fastercsv')
+          libs.keys.should_not include('fastercsv')
         end
       end
     end
@@ -74,6 +86,40 @@ require 'spec_helper'
         ENV['BUNDLER_EXT_NOSTRICT'] = 'true'
         BundlerExt.system_require(@gemfile)
         defined?(Gem::Command).should be_true
+      end
+
+      unless skip_system
+        context "ENV['BEXT_ACTIVATE_VERSIONS'] is true" do
+          before(:each) do
+            ENV['BUNDLER_EXT_NOSTRICT'] = 'true'
+            ENV['BEXT_ACTIVATE_VERSIONS'] = 'true'
+          end
+
+          it "activates the version of the system installed package" do
+            gems = BundlerExt.parse_from_gemfile(@gemfile, :all)
+            gems.each { |gem,gdep|
+              version = rand(100)
+              BundlerExt.should_receive(:system_gem_name_for).with(gem).
+                         and_return(gem)
+              BundlerExt.should_receive(:system_gem_version_for).with(gem).
+                         and_return(version)
+              BundlerExt.should_receive(:gem).with(gem, "=#{version}")
+            }
+            BundlerExt.system_require(@gemfile, :all)
+          end
+
+          context "ENV['BEXT_PKG_PREFIX'] is specified" do
+            it "prepends bundler pkg prefix onto system package name to load" do
+              ENV['BEXT_PKG_PREFIX'] = 'rubygem-'
+              gems = BundlerExt.parse_from_gemfile(@gemfile, :all)
+              gems.each { |gem,gdep|
+                BundlerExt.should_receive(:system_gem_version_for).with("rubygem-#{gem}").
+                           and_return('0')
+              }
+              BundlerExt.system_require(@gemfile, :all)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This patch adds functionality to lookup and active system installed (eg installed with yum/apt/rpm/dpkg) gems to bundler_ext. The specific versions of the gems to activate are using the native package system tooling, as made available through linux_admin. This allows bundler_ext to use/activate system packages while still allowing other versions of those gems to be available for use elsewhere.

This functionality is initially disabled w/ bundler_ext acting 100% the same as it did in the default scenario. If the end user sets the BEXT_ACTIVATE_VERSIONS env variable to true, the system dependencies will be looked up as described. To map Gemfile gem dependencies to system packages, the end user may also set the BEXT_PKG_PREFIX env variable, specifying a string to prepend to package names before looking up (for example rubygem-).

Specs have been updated / added to test new functionality.
