### PR TITLE
Shorten ENV variable names to 'BEXT'

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,21 @@ case, this is not the desired behavior, we explicitly want to say
 There are special environment variables you can use. You may need to 
 insert additional groups to be required, e.g. when developing and you
 want to restart the system in development mode once. Use 
-BUNDLER_EXT_GROUPS variable (separate with whitespace):
+BEXT_GROUPS variable (separate with whitespace):
 
-    BUNDLER_EXT_GROUPS="group1 group2 group3" rails server ...
+    BEXT_GROUPS="group1 group2 group3" rails server ...
 
 Also, by default bundler_ext raises an error when dependency cannot
 be loaded. You can turn off this behavior (e.g. for installers when
-you want to do rake db:migrate) with setting BUNDLER_EXT_NOSTRICT:
+you want to do rake db:migrate) with setting BEXT_NOSTRICT:
 
-    BUNDLER_EXT_NOSTRICT=1 rake db:migrate ...
+    BEXT_NOSTRICT=1 rake db:migrate ...
 
 In this mode bundler_ext prints out error messages on the stdout, 
 but does not terminate the process.
 
 Some rubygems require HOME environment variable to be set, threfore
-not running daemonized. For this purposes there is BUNDLER_EXT_HOME
+not running daemonized. For this purposes there is BEXT_HOME
 variable which can be used to set HOME environment variable before
 any rubygem gets loaded. The variable is not exported for
 subprocesses.

--- a/lib/bundler_ext/bundler_ext.rb
+++ b/lib/bundler_ext/bundler_ext.rb
@@ -1,12 +1,14 @@
 require "bundler"
 
 # some rubygems does not play well with daemonized processes ($HOME is empty)
+ENV['HOME'] = ENV['BEXT_HOME']        if ENV['BEXT_HOME']
 ENV['HOME'] = ENV['BUNDLER_EXT_HOME'] if ENV['BUNDLER_EXT_HOME']
 
 class BundlerExt
   def self.parse_from_gemfile(gemfile,*groups)
     ENV['BUNDLE_GEMFILE'] = gemfile
     extra_groups = ENV['BUNDLER_EXT_GROUPS']
+    extra_groups = ENV['BEXT_GROUPS'] || ENV['BUNDLER_EXT_GROUPS']
     extra_groups.split(/\s/).each {|g| groups << g.to_sym} if extra_groups
     all_groups = false
     all_groups = true if groups.size == 1 and groups.include?(:all) and not extra_groups
@@ -35,7 +37,7 @@ class BundlerExt
   end
 
   def self.strict_error(msg)
-    if ENV['BUNDLER_EXT_NOSTRICT']
+    if ENV['BEXT_NOSTRICT'] || ENV['BUNDLER_EXT_NOSTRICT']
       puts msg
     else
       raise msg

--- a/spec/bundler_ext/bundler_ext_spec.rb
+++ b/spec/bundler_ext/bundler_ext_spec.rb
@@ -13,11 +13,11 @@ end
       @gemfile = 'spec/fixtures/Gemfile.in'
     end
     after(:each) do
-      ENV['BUNDLER_EXT_NOSTRICT'] = nil
-      ENV['BUNDLER_EXT_GROUPS'] = nil
       ENV['BUNDLER_PKG_PREFIX'] = nil
       ENV['BEXT_ACTIVATE_VERSIONS'] = nil
       ENV['BEXT_PKG_PREFIX'] = nil
+      ENV['BEXT_NOSTRICT'] = nil
+      ENV['BEXT_GROUPS'] = nil
     end
 
     describe "#parse_from_gemfile" do
@@ -71,19 +71,40 @@ end
       it "strict mode should fail loading non existing gem" do
         expect { BundlerExt.system_require(@gemfile, :fail) }.to raise_error
       end
+
+      it "non-strict mode should load the libraries in the gemfile" do
+        ENV['BEXT_NOSTRICT'] = 'true'
+        BundlerExt.system_require(@gemfile)
+        defined?(Gem).should be_true
+      end
+
       it "non-strict mode should load the libraries in the gemfile" do
         ENV['BUNDLER_EXT_NOSTRICT'] = 'true'
         BundlerExt.system_require(@gemfile)
         defined?(Gem).should be_true
       end
+
+      it "non-strict mode should load the libraries in the gemfile" do
+        ENV['BEXT_NOSTRICT'] = 'true'
+        BundlerExt.system_require(@gemfile, :fail)
+        defined?(Gem).should be_true
+      end
+
       it "non-strict mode should load the libraries in the gemfile" do
         ENV['BUNDLER_EXT_NOSTRICT'] = 'true'
         BundlerExt.system_require(@gemfile, :fail)
         defined?(Gem).should be_true
       end
       it "non-strict mode should load the libraries using env var list" do
-        ENV['BUNDLER_EXT_GROUPS'] = 'test development blah'
-        ENV['BUNDLER_EXT_NOSTRICT'] = 'true'
+        ENV['BEXT_GROUPS'] = 'test development blah'
+        ENV['BEXT_NOSTRICT'] = 'true'
+        BundlerExt.system_require(@gemfile)
+        defined?(Gem::Command).should be_true
+      end
+
+      it "non-strict mode should load the libraries using env var list" do
+        ENV['BUNLDER_EXT_GROUPS'] = 'test development blah'
+        ENV['BEXT_NOSTRICT'] = 'true'
         BundlerExt.system_require(@gemfile)
         defined?(Gem::Command).should be_true
       end


### PR DESCRIPTION
Restores consistency w/ bundler_ext after https://github.com/bundlerext/bundler_ext/pull/12 takes effect
